### PR TITLE
Issue/23 daily reports data

### DIFF
--- a/app/api/users/[userId]/daily_reports/[id]/edit/route.ts
+++ b/app/api/users/[userId]/daily_reports/[id]/edit/route.ts
@@ -1,0 +1,48 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const supabase = await createClient();
+  const { id } = params;
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+
+  // フロントエンドのプロパティ名(mood, achievementsなど)をDBのカラム名(face, good_thingなど)に変換
+  const { title, mood, achievements, challenges, learnings, report_date } =
+    body;
+
+  const reportDataToUpdate: { [key: string]: any } = {};
+  if (title !== undefined) reportDataToUpdate.title = title;
+  if (mood !== undefined) reportDataToUpdate.face = mood;
+  if (achievements !== undefined) reportDataToUpdate.good_thing = achievements;
+  if (challenges !== undefined) reportDataToUpdate.bad_thing = challenges;
+  if (learnings !== undefined) reportDataToUpdate.message = learnings;
+  if (report_date !== undefined) reportDataToUpdate.report_date = report_date;
+
+  // RLSが有効なため、task_managerロールを持つユーザーのみが更新可能
+  const { error } = await supabase
+    .from("daily_reports")
+    .update(reportDataToUpdate)
+    .eq("id", id);
+
+  if (error) {
+    console.error("Error updating daily report:", error);
+    return NextResponse.json(
+      { error: `Failed to update daily report: ${error.message}` },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ message: "Success" });
+}

--- a/app/api/users/[userId]/daily_reports/[id]/route.ts
+++ b/app/api/users/[userId]/daily_reports/[id]/route.ts
@@ -1,0 +1,31 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const supabase = await createClient();
+  const { id } = params;
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // RLSが有効なため、task_managerロールを持つユーザーのみが削除可能
+  const { error } = await supabase.from("daily_reports").delete().eq("id", id);
+
+  if (error) {
+    console.error("Error deleting daily report:", error);
+    return NextResponse.json(
+      { error: "Failed to delete daily report" },
+      { status: 500 }
+    );
+  }
+
+  return new NextResponse(null, { status: 204 }); // No Content
+}

--- a/app/api/users/[userId]/daily_reports/new/route.ts
+++ b/app/api/users/[userId]/daily_reports/new/route.ts
@@ -1,0 +1,47 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { userId: string } }
+) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // RLSが有効なため、userIdは認証ユーザーのものと一致する必要があるか、
+  // もしくは操作者がtask_managerである必要があります。
+  const body = await request.json();
+
+  // フロントエンドのプロパティ名をDBのカラム名に変換
+  const { title, mood, achievements, challenges, learnings } = body;
+  const reportDataToInsert = {
+    title,
+    face: mood,
+    good_thing: achievements,
+    bad_thing: challenges,
+    message: learnings,
+    user_id: params.userId,
+    report_date: new Date().toISOString(), // report_dateをISO文字列で設定
+  };
+
+  const { error } = await supabase
+    .from("daily_reports")
+    .insert(reportDataToInsert);
+
+  if (error) {
+    console.error("Error creating daily report:", error);
+    return NextResponse.json(
+      { error: "Failed to create daily report" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ message: "Success" }, { status: 201 });
+}

--- a/app/users/[user_id]/daily_reports/[id]/edit/page.tsx
+++ b/app/users/[user_id]/daily_reports/[id]/edit/page.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import { notFound } from "next/navigation";
+import { ReportForm } from "@/components/daily-reports/report-form";
+import { getDailyReportById } from "@/lib/data/daily-reports";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function EditDailyReportPage({
+  params,
+}: {
+  params: { user_id: string; id: string };
+}) {
+  const { user_id, id } = params;
+
+  const [report, supabase] = await Promise.all([
+    getDailyReportById(id),
+    createClient(),
+  ]);
+
+  if (!report) {
+    notFound();
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("name")
+    .eq("id", user_id)
+    .single();
+
+  return (
+    <div className="container mx-auto py-10">
+      <div className="flex items-center gap-4 mb-6">
+        <Link href={`/users/${user_id}/daily_reports`}>
+          <Button variant="outline" size="icon">
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        </Link>
+        <div>
+          <p className="text-sm text-muted-foreground">
+            {profile?.name ?? "ユーザー"} の日報を編集
+          </p>
+          <h1 className="text-3xl font-bold">Edit Daily Report</h1>
+        </div>
+      </div>
+      <ReportForm initialData={report} />
+    </div>
+  );
+}

--- a/app/users/[user_id]/daily_reports/[id]/page.tsx
+++ b/app/users/[user_id]/daily_reports/[id]/page.tsx
@@ -1,0 +1,96 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getDailyReportById } from "@/lib/data/daily-reports";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { ArrowLeft } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+const moodMap: { [key: string]: { label: string; className: string } } = {
+  smile: { label: "😊 良い", className: "bg-green-100 text-green-800" },
+  normal: { label: "😐 普通", className: "bg-yellow-100 text-yellow-800" },
+  sad: { label: "😥 悪い", className: "bg-red-100 text-red-800" },
+};
+
+export default async function DailyReportDetailPage({
+  params,
+}: {
+  params: { user_id: string; id: string };
+}) {
+  const { user_id, id } = params;
+  const report = await getDailyReportById(id);
+
+  if (!report) {
+    notFound();
+  }
+
+  const renderMarkdown = (text: string | null) => {
+    if (!text) return <p className="text-muted-foreground">記載なし</p>;
+    return (
+      <div className="prose prose-sm dark:prose-invert max-w-none">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
+      </div>
+    );
+  };
+
+  return (
+    <div className="container mx-auto py-10">
+      <div className="mb-6">
+        <Button variant="outline" size="sm" asChild>
+          <Link href={`/users/${user_id}/daily_reports`}>
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            一覧へ戻る
+          </Link>
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-3xl">{report.title}</CardTitle>
+          <CardDescription className="flex items-center gap-4 pt-2">
+            <span>
+              日付: {new Date(report.report_date).toLocaleDateString()}
+            </span>
+            <span>
+              気分:{" "}
+              <Badge
+                variant="outline"
+                className={moodMap[report.mood]?.className}
+              >
+                {moodMap[report.mood]?.label ?? report.mood}
+              </Badge>
+            </span>
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="space-y-2">
+            <h3 className="text-lg font-semibold border-b pb-2">
+              よかった事 (Achievements)
+            </h3>
+            <div className="p-2">{renderMarkdown(report.achievements)}</div>
+          </div>
+          <div className="space-y-2">
+            <h3 className="text-lg font-semibold border-b pb-2">
+              悪かった事 (Challenges)
+            </h3>
+            <div className="p-2">{renderMarkdown(report.challenges)}</div>
+          </div>
+          <div className="space-y-2">
+            <h3 className="text-lg font-semibold border-b pb-2">
+              伝えたい事 (Learnings)
+            </h3>
+            <div className="p-2">{renderMarkdown(report.learnings)}</div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/users/[user_id]/daily_reports/new/page.tsx
+++ b/app/users/[user_id]/daily_reports/new/page.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import { createClient } from "@/lib/supabase/server";
+import { notFound } from "next/navigation";
+import { ReportForm } from "@/components/daily-reports/report-form";
+
+export default async function NewDailyReportPage({
+  params,
+}: {
+  params: { user_id: string };
+}) {
+  const supabase = await createClient();
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("name")
+    .eq("id", params.user_id)
+    .single();
+
+  if (!profile) {
+    notFound();
+  }
+
+  return (
+    <div className="container mx-auto py-10">
+      <div className="flex items-center gap-4 mb-6">
+        <Link href={`/users/${params.user_id}/daily_reports`}>
+          <Button variant="outline" size="icon">
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        </Link>
+        <div>
+          <p className="text-sm text-muted-foreground">
+            {profile.name} の日報を新規作成
+          </p>
+          <h1 className="text-3xl font-bold">New Daily Report</h1>
+        </div>
+      </div>
+      <ReportForm />
+    </div>
+  );
+}

--- a/app/users/[user_id]/schedule/page.tsx
+++ b/app/users/[user_id]/schedule/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { dummyTasks } from "@/lib/dummy-data";
+import { useEffect, useState } from "react";
+import { getTasks } from "@/lib/dummy-data";
+import { Task } from "@/lib/definitions";
 import Calendar from "@/components/tasks/schedule/calendar";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
@@ -8,6 +10,20 @@ import { ArrowLeft } from "lucide-react";
 
 export default function SchedulePage() {
   const router = useRouter();
+  const [tasks, setTasks] = useState<Task[]>([]);
+
+  useEffect(() => {
+    const fetchTasks = async () => {
+      try {
+        const fetchedTasks = await getTasks();
+        setTasks(fetchedTasks);
+      } catch (error) {
+        console.error("Failed to fetch tasks:", error);
+      }
+    };
+
+    fetchTasks();
+  }, []);
 
   return (
     <div className="space-y-6">
@@ -23,7 +39,7 @@ export default function SchedulePage() {
         </div>
       </div>
 
-      <Calendar tasks={dummyTasks} />
+      <Calendar tasks={tasks} />
     </div>
   );
 }

--- a/components/daily-reports/delete-button.tsx
+++ b/components/daily-reports/delete-button.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+
+type DeleteButtonProps = {
+  userId: string;
+  reportId: string;
+};
+
+export function DeleteButton({ userId, reportId }: DeleteButtonProps) {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const router = useRouter();
+
+  const handleDelete = async () => {
+    if (!confirm("本当にこの日報を削除しますか？")) {
+      return;
+    }
+
+    setIsDeleting(true);
+
+    try {
+      const response = await fetch(
+        `/api/users/${userId}/daily_reports/${reportId}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error("日報の削除に失敗しました。");
+      }
+
+      toast.success("日報を削除しました。");
+      router.refresh();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "不明なエラーが発生しました。"
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <Button
+      variant="destructive"
+      size="sm"
+      onClick={handleDelete}
+      disabled={isDeleting}
+    >
+      {isDeleting ? "削除中..." : "削除"}
+    </Button>
+  );
+}

--- a/components/daily-reports/report-form.tsx
+++ b/components/daily-reports/report-form.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { toast } from "sonner";
+import { DailyReport } from "@/lib/definitions";
+
+// Mappings to handle mood value conversion between API (face) and form (mood)
+const moodApiToForm: { [key: string]: "良い" | "普通" | "悪い" } = {
+  smile: "良い",
+  good: "良い",
+  normal: "普通",
+  sad: "悪い",
+  bad: "悪い",
+  良い: "良い",
+  普通: "普通",
+  悪い: "悪い",
+};
+
+const moodFormToApi: { 良い: "smile"; 普通: "normal"; 悪い: "sad" } = {
+  良い: "smile",
+  普通: "normal",
+  悪い: "sad",
+};
+
+type ReportFormProps = {
+  initialData?: DailyReport | null;
+};
+
+export function ReportForm({ initialData }: ReportFormProps) {
+  const [title, setTitle] = useState("");
+  const [mood, setMood] = useState<"良い" | "普通" | "悪い" | "">("");
+  const [achievements, setAchievements] = useState("");
+  const [challenges, setChallenges] = useState("");
+  const [learnings, setLearnings] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const params = useParams();
+  const router = useRouter();
+  const userId = params.user_id as string;
+  const reportId = params.id as string;
+
+  const isEditMode = !!initialData;
+
+  useEffect(() => {
+    if (isEditMode && initialData) {
+      setTitle(initialData.title);
+      setMood(moodApiToForm[initialData.mood] || "");
+      setAchievements(initialData.achievements || "");
+      setChallenges(initialData.challenges || "");
+      setLearnings(initialData.learnings || "");
+    }
+  }, [isEditMode, initialData]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    if (!title || !mood) {
+      toast.error("タイトルと今の気分は必須です。");
+      setIsSubmitting(false);
+      return;
+    }
+
+    const reportData = {
+      title,
+      mood: mood ? moodFormToApi[mood] : undefined,
+      achievements,
+      challenges,
+      learnings,
+    };
+
+    try {
+      const url = isEditMode
+        ? `/api/users/${userId}/daily_reports/${reportId}/edit`
+        : `/api/users/${userId}/daily_reports/new`;
+      const method = isEditMode ? "PATCH" : "POST";
+
+      const response = await fetch(url, {
+        method: method,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(reportData),
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `日報の${isEditMode ? "更新" : "作成"}に失敗しました。`
+        );
+      }
+
+      toast.success(`日報を${isEditMode ? "更新" : "作成"}しました！`);
+      router.push(`/users/${userId}/daily_reports`);
+      router.refresh();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "不明なエラーが発生しました。"
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Card>
+        <CardHeader>
+          <CardTitle>日報の内容</CardTitle>
+          <CardDescription>
+            {isEditMode
+              ? "日報を編集します。"
+              : "今日一日の活動を記録しましょう。"}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="space-y-2">
+              <Label htmlFor="title">タイトル</Label>
+              <Input
+                id="title"
+                placeholder="例: ○○機能の実装"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="mood">今の気分</Label>
+              <Select
+                onValueChange={(value: "良い" | "普通" | "悪い") =>
+                  setMood(value)
+                }
+                value={mood}
+                required
+              >
+                <SelectTrigger id="mood">
+                  <SelectValue placeholder="気分を選択" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="良い">😊 良い</SelectItem>
+                  <SelectItem value="普通">😐 普通</SelectItem>
+                  <SelectItem value="悪い">😥 悪い</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="achievements">よかった事 (Achievements)</Label>
+            <Textarea
+              id="achievements"
+              placeholder="今日達成できたこと、うまくいったことなどを記入してください。"
+              value={achievements}
+              onChange={(e) => setAchievements(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="challenges">悪かった事 (Challenges)</Label>
+            <Textarea
+              id="challenges"
+              placeholder="課題だと感じたこと、うまくいかなかったことなどを記入してください。"
+              value={challenges}
+              onChange={(e) => setChallenges(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="learnings">伝えたい事 (Learnings)</Label>
+            <Textarea
+              id="learnings"
+              placeholder="学んだこと、気づいたこと、チームに共有したいことなどを記入してください。"
+              value={learnings}
+              onChange={(e) => setLearnings(e.target.value)}
+            />
+          </div>
+        </CardContent>
+        <CardFooter className="flex justify-end">
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting
+              ? "提出中..."
+              : isEditMode
+              ? "日報を更新"
+              : "日報を提出"}
+          </Button>
+        </CardFooter>
+      </Card>
+    </form>
+  );
+}

--- a/lib/data/daily-reports.ts
+++ b/lib/data/daily-reports.ts
@@ -1,0 +1,82 @@
+// lib/data/daily-reports.ts
+import { createClient } from "@/lib/supabase/server";
+import { DailyReport } from "@/lib/definitions";
+import { unstable_noStore as noStore } from "next/cache";
+
+// DBから取得した生の型 (カラム名に準拠)
+// この型はエクスポートせず、このファイル内でのみ使用する
+type RawDailyReport = {
+  id: string;
+  user_id: string;
+  title: string;
+  face: "良い" | "普通" | "悪い";
+  good_thing: string;
+  bad_thing: string;
+  message: string;
+  report_date: string;
+  created_at: string;
+  updated_at: string;
+};
+
+// 生のDBデータをフロントエンドの型に変換する
+const transformReport = (raw: RawDailyReport): DailyReport => {
+  return {
+    id: raw.id,
+    user_id: raw.user_id,
+    title: raw.title,
+    report_date: raw.report_date,
+    created_at: raw.created_at,
+    updated_at: raw.updated_at,
+    // カラム名とプロパティ名のマッピング
+    mood: raw.face,
+    achievements: raw.good_thing,
+    challenges: raw.bad_thing,
+    learnings: raw.message,
+    next_day_goals: "", // DBにカラムがないため空文字
+  };
+};
+
+// ユーザーIDに基づいて日報一覧を取得
+export const getDailyReportsByUserId = async (
+  userId: string
+): Promise<DailyReport[]> => {
+  noStore(); // 動的レンダリングを強制
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("daily_reports")
+    .select("*")
+    .eq("user_id", userId)
+    .order("report_date", { ascending: false });
+
+  if (error) {
+    console.error("Error fetching daily reports:", error);
+    throw new Error("Failed to fetch daily reports.");
+  }
+  // 取得したデータを変換
+  return data.map(transformReport);
+};
+
+// IDによって特定の日報を取得
+export const getDailyReportById = async (
+  id: string
+): Promise<DailyReport | null> => {
+  noStore();
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("daily_reports")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (error && error.code !== "PGRST116") {
+    // PGRST116は行が見つからない場合のエラーコードなので、それは無視する
+    console.error("Error fetching daily report:", error);
+    throw new Error("Failed to fetch daily report.");
+  }
+
+  if (!data) {
+    return null;
+  }
+  // 取得したデータを変換
+  return transformReport(data);
+};

--- a/lib/definitions.ts
+++ b/lib/definitions.ts
@@ -20,14 +20,23 @@ export type Profile = {
   updated_at: string;
 };
 
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  role: "task_manager" | "commenter";
+}
+
 export type DailyReport = {
   id: string;
   user_id: string;
+  title: string;
+  mood: "良い" | "普通" | "悪い" | "smile" | "normal" | "sad"; // `face` カラムに対応
+  achievements: string; // `good_thing` カラムに対応
+  challenges: string; // `bad_thing` カラムに対応
+  learnings: string; // `message` カラムに対応
+  next_day_goals: string; // 将来的な拡張用
   report_date: string;
-  mood: "良い" | "普通" | "悪い";
-  achievements: string | null;
-  challenges: string | null;
-  learnings: string | null;
-  next_day_goals: string | null;
   created_at: string;
+  updated_at: string;
 };

--- a/lib/dummy-data.ts
+++ b/lib/dummy-data.ts
@@ -1,6 +1,23 @@
-import { Task, DailyReport } from "./definitions";
+import { DailyReport, User, Task } from "./definitions";
 
-export const dummyTasks: Task[] = [
+// Users Data
+export const users: User[] = [
+  {
+    id: "user-1",
+    name: "yasuda naoto",
+    email: "user1@example.com",
+    role: "task_manager",
+  },
+  {
+    id: "user-2",
+    name: "Jane Smith",
+    email: "user2@example.com",
+    role: "commenter",
+  },
+];
+
+// Tasks Data
+export const tasks: Task[] = [
   {
     id: "task-1",
     title: "タスク1：共通レイアウトの実装",
@@ -69,60 +86,21 @@ export const dummyTasks: Task[] = [
   },
 ];
 
-export const dummyReports: DailyReport[] = [
-  {
-    id: "report-1",
-    user_id: "user-1",
-    report_date: "2024-07-20",
-    mood: "良い",
-    achievements: "日報一覧ページの実装を完了した。",
-    challenges: "TypeScriptの型エラーで少し詰まった。",
-    learnings: "shadcn/uiのTableコンポーネントの使い方がわかった。",
-    next_day_goals: "日報の詳細ページを作成する。",
-    created_at: "2024-07-20T18:00:00Z",
-  },
-  {
-    id: "report-2",
-    user_id: "user-1",
-    report_date: "2024-07-19",
-    mood: "普通",
-    achievements: "ログイン機能のリファクタリング。",
-    challenges: "リダイレクトの仕様を理解するのに時間がかかった。",
-    learnings: "Next.jsのMiddlewareの動作について学んだ。",
-    next_day_goals: "日報一覧ページに着手する。",
-    created_at: "2024-07-19T19:30:00Z",
-  },
-  {
-    id: "report-3",
-    user_id: "user-2",
-    report_date: "2024-07-20",
-    mood: "悪い",
-    achievements: "環境構築で1日が終わってしまった。",
-    challenges: "Node.jsのバージョン問題。",
-    learnings: "nvmを使ったバージョン管理の重要性を再認識した。",
-    next_day_goals: "今日こそはコーディングを始める。",
-    created_at: "2024-07-20T20:00:00Z",
-  },
-];
-
-export const getAllTasks = async (): Promise<Task[]> => {
-  // In a real application, you would fetch this data from a database.
-  // For now, we're returning the dummy data.
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve(dummyTasks);
-    }, 500); // Simulate network latency
-  });
+// ダミーデータ取得用の関数
+export const getUsers = async (): Promise<User[]> => {
+  return new Promise((resolve) => setTimeout(() => resolve(users), 500));
 };
 
 export const getDailyReportsByUserId = async (
   userId: string
 ): Promise<DailyReport[]> => {
-  // For now, we're returning dummy data filtered by userId.
-  const reports = dummyReports.filter((report) => report.user_id === userId);
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve(reports);
-    }, 300); // Simulate network latency
-  });
+  console.log("Fetching daily reports for user:", userId, "from dummy data.");
+  // This function will be replaced with a real DB access later.
+  // For now, it returns an empty array until Supabase connection is complete.
+  return new Promise((resolve) => setTimeout(() => resolve([]), 500));
+};
+
+export const getTasks = async (): Promise<Task[]> => {
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  return tasks;
 };


### PR DESCRIPTION
### [issue/23-daily_reports_data ブランチの変更内容の要約](https://github.com/nto300002/smooth_progress_management/compare/issue/23-daily_reports_data?expand=1)

このブランチでは、日報のCRUD（作成、読み取り、更新、削除）機能に関する一連の実装が行われています。変更は、データ層からAPI、そしてUIコンポーネント、最終的なページへと積み上げる形で行われています。

1.  **データ定義と準備 (lib)**
    *   `fix/lib: bummy-data ...`: `lib/dummy-data.ts`にあった日報関連のダミーデータへの依存をなくす修正が行われました。
    *   `add/types: reports`: `lib/definitions.ts`に日報の型定義 (`DailyReport`) が追加・更新されました。
    *   `add/lib: getDailyReports method`: `lib/data/daily-reports.ts`が新設され、SupabaseからユーザーIDに基づいて日報を取得する関数 (`getDailyReportsByUserId`など) が実装されました。

2.  **UIコンポーネント (components)**
    *   `add/components: crud form & button`: 日報の作成と編集で再利用されるフォーム (`report-form.tsx`) と、削除を実行するためのボタン (`delete-button.tsx`) が新しく作成されました。

3.  **APIエンドポイント (app/api)**
    *   `add/api: reportData`: 日報のCRUD操作を行うためのサーバーサイドのAPIが実装されました。これには、新規作成 (`.../new/route.ts`)、更新 (`.../edit/route.ts`)、削除 (`.../[id]/route.ts`) のエンドポイントが含まれます。

4.  **ページ (app/users)**
    *   `add/pages: reportPages + crud api`: ユーザーが実際に操作する日報の各ページが作成されました。
        *   新規作成ページ (`.../new/page.tsx`)
        *   編集ページ (`.../edit/page.tsx`)
        *   詳細表示ページ (`.../[id]/page.tsx`)
    *   `add/pages: schedule fetch tasks`: 日報機能とは直接関連が薄いですが、スケジュールのタスク取得ロジックにも変更が加えられています。